### PR TITLE
Added STATICFILES_STORAGE to fix ValueError

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ cache-busting, split chunks.
 
 ## Quick reference:
 
+Add `manifest_loader` to your `INSTALLED_APPS` and:
+
+```
+STATICFILES_STORAGE = 'manifest_loader.storage.DjangoManifestLoaderStorage'
+```
+
+
 ### Manifest tag
 
 ```djangotemplate

--- a/manifest_loader/storage.py
+++ b/manifest_loader/storage.py
@@ -1,0 +1,8 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class DjangoManifestLoaderStorage(ManifestStaticFilesStorage):
+    """
+    If a file isn’t found in the staticfiles.json manifest at runtime, don't raise an exception
+    """
+    manifest_strict = False


### PR DESCRIPTION
Added STATICFILES_STORAGE to fix ValueError raised when a file is not at the manifest file.

As seen here https://docs.djangoproject.com/en/3.2/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.manifest_strict

You hit this error when compiling takes some time.